### PR TITLE
Adding safeguard on null object

### DIFF
--- a/geo-mashup.php
+++ b/geo-mashup.php
@@ -717,7 +717,10 @@ class GeoMashup {
 		$objects = GeoMashupDB::get_object_locations( $query_args );
 		if ( $objects ) {
 			foreach ($objects as $object) {
-				$json_objects[] = self::augment_map_object_location( $query_args['object_name'], $object );
+				$obj = self::augment_map_object_location( $query_args['object_name'], $object );
+				if ($obj) {
+					$json_objects[] = $obj;
+				}
 			}
 		}
 		if ( ARRAY_A == $format ) 


### PR DESCRIPTION
This change prevents null object to be added. This in turn allows localization plugin such as Polylang, to filter objects on map, based on selected language.