### PR TITLE
Corrected plugin textdomain loading hook

### DIFF
--- a/geo-mashup.php
+++ b/geo-mashup.php
@@ -252,7 +252,6 @@ class GeoMashup {
 		define('GEO_MASHUP_PLUGIN_NAME', plugin_basename(__FILE__));
 		/** @noinspection DirectoryConstantCanBeUsedInspection */
 		define('GEO_MASHUP_DIR_PATH', dirname( __FILE__ ));
-		define('GEO_MASHUP_DIRECTORY', dirname( GEO_MASHUP_PLUGIN_NAME ) );
 		define('GEO_MASHUP_URL_PATH', trim( plugin_dir_url( __FILE__ ), '/' ) );
 		define('GEO_MASHUP_MAX_ZOOM', 20);
 		define('GEO_MASHUP_VERSION', '1.11.4');

--- a/geo-mashup.php
+++ b/geo-mashup.php
@@ -152,7 +152,7 @@ class GeoMashup {
 	 */
 	public static function load_integrations() {
 
-		load_plugin_textdomain( 'GeoMashup', false, GEO_MASHUP_DIR_PATH . '/lang' );
+		load_plugin_textdomain( 'GeoMashup', false, GEO_MASHUP_DIRECTORY . '/lang' );
 
 		if ( defined( 'ICL_LANGUAGE_CODE' ) ) {
 			include_once GEO_MASHUP_DIR_PATH . '/wpml.php';
@@ -252,6 +252,7 @@ class GeoMashup {
 		define('GEO_MASHUP_PLUGIN_NAME', plugin_basename(__FILE__));
 		/** @noinspection DirectoryConstantCanBeUsedInspection */
 		define('GEO_MASHUP_DIR_PATH', dirname( __FILE__ ));
+		define('GEO_MASHUP_DIRECTORY', dirname( GEO_MASHUP_PLUGIN_NAME ) );
 		define('GEO_MASHUP_URL_PATH', trim( plugin_dir_url( __FILE__ ), '/' ) );
 		define('GEO_MASHUP_MAX_ZOOM', 20);
 		define('GEO_MASHUP_VERSION', '1.11.4');

--- a/geo-mashup.php
+++ b/geo-mashup.php
@@ -82,8 +82,6 @@ class GeoMashup {
 	 */
 	public static function load() {
 		self::load_constants();
-		load_plugin_textdomain( 'GeoMashup', '', path_join( GEO_MASHUP_DIRECTORY, 'lang' ) );
-
 		self::load_dependencies();
 		self::load_hooks();
 	}
@@ -153,6 +151,8 @@ class GeoMashup {
 	 * @since 1.10.0
 	 */
 	public static function load_integrations() {
+
+		load_plugin_textdomain( 'GeoMashup', false, GEO_MASHUP_DIR_PATH . '/lang' );
 
 		if ( defined( 'ICL_LANGUAGE_CODE' ) ) {
 			include_once GEO_MASHUP_DIR_PATH . '/wpml.php';

--- a/gm-location-query.php
+++ b/gm-location-query.php
@@ -132,7 +132,10 @@ class GM_Location_Query {
 		if ( is_numeric( $this->query_args['maxlat'] ) ) $where[] = "$location_table.lat < {$this->query_args['maxlat']}";
 		if ( is_numeric( $this->query_args['maxlon'] ) ) $where[] = "$location_table.lng < {$this->query_args['maxlon']}";
 
-		$where_fields = array( 'sub_admin_code', 'admin_code', 'country_code', 'postal_code', 'geoname', 'locality_name', 'saved_name' );
+		// Postal codes and partial postal codes
+		if ( $this->query_args['postal_code'] ) $where[] = $wpdb->prepare( "$location_table.postal_code REGEXP %s", '^'.$this->query_args['postal_code'] );
+
+		$where_fields = array( 'sub_admin_code', 'admin_code', 'country_code', 'geoname', 'locality_name', 'saved_name' );
 		foreach ( $where_fields as $field ) {
 			if ( !empty( $this->query_args[$field] ) )
 				$where[] = $wpdb->prepare( "$location_table.$field = %s", $this->query_args[$field] );

--- a/gm-location-query.php
+++ b/gm-location-query.php
@@ -132,10 +132,7 @@ class GM_Location_Query {
 		if ( is_numeric( $this->query_args['maxlat'] ) ) $where[] = "$location_table.lat < {$this->query_args['maxlat']}";
 		if ( is_numeric( $this->query_args['maxlon'] ) ) $where[] = "$location_table.lng < {$this->query_args['maxlon']}";
 
-		// Postal codes and partial postal codes
-		if ( $this->query_args['postal_code'] ) $where[] = $wpdb->prepare( "$location_table.postal_code REGEXP %s", '^'.$this->query_args['postal_code'] );
-
-		$where_fields = array( 'sub_admin_code', 'admin_code', 'country_code', 'geoname', 'locality_name', 'saved_name' );
+		$where_fields = array( 'sub_admin_code', 'admin_code', 'postal_code', 'country_code', 'geoname', 'locality_name', 'saved_name' );
 		foreach ( $where_fields as $field ) {
 			if ( !empty( $this->query_args[$field] ) )
 				$where[] = $wpdb->prepare( "$location_table.$field = %s", $this->query_args[$field] );


### PR DESCRIPTION
[load_plugin_textdomain](https://codex.wordpress.org/Function_Reference/load_plugin_textdomain) should be hooked to the plugins_loaded action.

Helpful, as user profile language is now used on the back end, rather than WP system language.

Path to lang dir now uses the GEO_MASHUP_DIR_PATH constant, so GEO_MASHUP_DIRECTORY was removed.