### PR TITLE
Update OpenLayers version

### DIFF
--- a/render-map.php
+++ b/render-map.php
@@ -206,9 +206,9 @@ class GeoMashupRenderMap {
 		if ( 'openlayers' === $map_data['map_api'] ) {
 			wp_register_script( 
 					'openlayers', 
-					'https://cdn.jsdelivr.net/gh/openlayers/openlayers.github.io@master/en/v6.3.1/build/ol.js',
+					'https://cdn.jsdelivr.net/gh/openlayers/openlayers.github.io@master/en/v6.5.0/build/ol.js',
 					null, 
-					'6.3.1',
+					'6.5.0',
 					true );
 
 			GeoMashup::register_style(


### PR DESCRIPTION
fixes #900
The CDN for OpenLayers 6.3.1 started throwing this error: The resource from “https://cdn.jsdelivr.net/gh/openlayers/openlayers.github.io@master/en/v6.3.1/build/ol.js?ver=6.3.1” was blocked due to MIME type (“text/plain”) mismatch (X-Content-Type-Options: nosniff).

A user suggested using version 6.5.0, and that seems to work. https://wordpress.org/support/topic/openlayers-js-library-not-loaded/#post-15994563

It does seem like openlayers has a build process now that might be better in the long run, made #901 for that.