### PR TITLE
Prevent fatal error on PHP 8.0+

### DIFF
--- a/geo-mashup-db.php
+++ b/geo-mashup-db.php
@@ -1912,9 +1912,12 @@ class GeoMashupDB {
 				if ( isset( $location['set_null'] ) ) {
 					// WP doesn't yet have a mechanism for setting NULLs, https://core.trac.wordpress.org/ticket/15158
 					$null_fields = $location['set_null'];
-					if ( !is_array( $null_fields ) ) 
+					if ( !is_array( $null_fields ) ) {
 						$null_fields = explode( ',', $null_fields );
-					$null_fields = array_map( create_function( '$field', 'return $field . "=NULL";' ), $null_fields );
+					}
+					$null_fields = array_map( function( $field ) {
+						return $field . "=NULL";
+					}, $null_fields );
 					$wpdb->query( $wpdb->prepare( "UPDATE $location_table SET " . implode( ',', $null_fields) . " WHERE id=%d", $db_location['id'] ) );
 					unset( $location['set_null'] );
 				}


### PR DESCRIPTION
As the title says - since `create_function` has been removed.